### PR TITLE
improve the runit and create_runscript.py scripts

### DIFF
--- a/create_runscript.py
+++ b/create_runscript.py
@@ -1,7 +1,7 @@
 from jinja2 import Template
 import os
 
-def create_runscript(exe, params, project_code, queue, script_dir, run_dir, log_file, run_script, namelist_input):
+def create_runscript(exe, params, project_code, FC, queue, module_load, script_dir, run_dir, log_file, run_script, namelist_input):
 
     if params['mpi'] is True:
         mpi = 'mpirun -n '+str(params['mpiprocs'])
@@ -19,8 +19,7 @@ def create_runscript(exe, params, project_code, queue, script_dir, run_dir, log_
 #PBS -A {{ project_code }}
 #PBS -q {{ queue }}
 
-module purge
-module load ncarenv/1.3 nvhpc/21.11 openmpi netcdf
+{{ module_load }}
 
 export LD_LIBRARY_PATH=${NCAR_ROOT_CUDA}/lib64:${LD_LIBRARY_PATH}
 export UCX_MEMTYPE_CACHE=n
@@ -43,10 +42,9 @@ cd {{ run_dir }}
 #PBS -l walltime={{ walltime }}
 #PBS -j oe
 #PBS -A {{ project_code }}
-#PBS -q casper
+#PBS -q {{ queue }}
 
-module purge
-module load ncarenv/1.3 nvhpc/21.11 openmpi netcdf
+{{ module_load }}
 
 cd {{ run_dir }}
 
@@ -67,7 +65,8 @@ cd {{ run_dir }}
               exe = exe,
               namelist_input = namelist_input,
               script_dir = script_dir,
-              log_file = log_file 
+              log_file = log_file,
+              module_load = module_load
             )
 
     with open(run_script, 'w') as f:

--- a/runit
+++ b/runit
@@ -142,7 +142,7 @@ for exe in exe_list:
         for namelist_input in namelist_input_list:
             # create a log file name
             # set version number to a time stamp
-            log_fn_base = exe + "." + FC_info + "." + HW + "." + namelist_input
+            log_fn_base = exe + "." + machine + "." + "HW" + "." + FC_info + "." + namelist_input
             log_fn = cwd + '/logs/' + log_fn_base + "." + verNum + '.log'
 
             print('############################################')

--- a/runit
+++ b/runit
@@ -13,8 +13,8 @@ import create_runscript
 #####################
 
 ### IMPORTANT: uncomment the type of run this is
-#run_type = "control"
-run_type = "experiment"
+run_type = "control"
+#run_type = "experiment"
 
 # This code creates a json file that lists the log file to use in the plots.  This flag controls the ability to
 # add this set of log files to the existing experiment file lists or should this set be the only files listed under the 
@@ -22,44 +22,44 @@ run_type = "experiment"
 add_to_experiment_list = True
 
 
-cm1_code_base = '/path/to/CM1/code/base/'
+cm1_code_base = '/glade/scratch/sunjian/temp/CM1/'
 project_code = 'NTDD0004'
-queue = 'gpgpu'
+queue = 'casper'
+machine = 'casper'
 namelist_input_list = [
 #    'namelist.asd04-128x512.input'
 #    'namelist.asd04-128x768.input',
 #    'namelist.asd04-128x1k.input'
 #    'namelist.verify.input',
-    'namelist.sas.input',
-    'namelist.asd03-128x512.input',
-    'namelist.asd04-128x512.input'
+#    'namelist.sas.input',
+    'namelist.asd03-verify.input'
+#    'namelist.asd04-128x512.input'
 ]
 exe_list = {
-'cm1-mpi.exe': {'args': 'FC=pgf90 USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=false DEBUG=false',
+'cm1-mpi.exe': {'args': 'FC=ifort USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=false DEBUG=false',
                           'mpi':True,
                           'nodes':1,
                           'ncpus':36,
                           'mpiprocs':36,
                           'ngpus':0,
                           'walltime':'00:30:00'
-                         },
-'cm1-openacc.exe': {'args': 'FC=pgf90 USE_MPI=false USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
-                          'mpi':False,
-                          'nodes':1,
-                          'ncpus':1,
-                          'mpiprocs':1,
-                          'ngpus':1,
-                          'walltime':'00:30:00'
-                         },
-'cm1-mpi-openacc.exe': {'args':'FC=pgf90 USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
-                          'mpi':True,
-                          'nodes':1,
-                          'ncpus':2,
-                          'mpiprocs':2,
-                          'ngpus':2,
-                          'walltime':'00:30:00'                                
                          }
-
+#'cm1-openacc.exe': {'args': 'FC=pgf90 USE_MPI=false USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
+#                          'mpi':False,
+#                          'nodes':1,
+#                          'ncpus':1,
+#                          'mpiprocs':1,
+#                          'ngpus':1,
+#                          'walltime':'00:30:00'
+#                         }
+#'cm1-mpi-openacc.exe': {'args':'FC=pgf90 USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
+#                          'mpi':True,
+#                          'nodes':1,
+#                          'ncpus':2,
+#                          'mpiprocs':2,
+#                          'ngpus':2,
+#                          'walltime':'00:30:00'                                
+#                         }
 }
 
 #####################
@@ -84,7 +84,15 @@ problem_builds = []
 successful_builds = []
 
 for exe in exe_list:
-
+    # get the Fortran compiler and OpenACC information
+    args_list=exe_list[exe]['args']
+    args_dict=dict(x.split("=") for x in args_list.split(" "))   
+    FC_info=args_dict['FC'].lower()
+    OpenACC_info=args_dict['USE_OPENACC'].lower()
+    if OpenACC_info:
+        HW="CPU"
+    else:
+        HW="GPU"
     # change to the src directory to build 
     print('\n\n\n\n\n\n')
     print('############################################')
@@ -92,9 +100,37 @@ for exe in exe_list:
     print('   Building code in '+cm1_code_base + '/src/')
     print('')
     print ('############################################')
-    os.chdir(cm1_code_base + "/src/") 
+    os.chdir(cm1_code_base + "/src/")
+    # load the modules based on FC_info
+    lmachine=machine.lower()
+    if FC_info == "ifort":
+        if lmachine == "casper":
+            module_load="module purge ; module load ncarenv/1.3 intel/19.1.1 openmpi/4.1.1 netcdf/4.8.1" 
+        elif lmachine == "cheyenne":
+            module_load="module purge ; module load ncarenv/1.3 intel/19.1.1 mpt/2.22 netcdf/4.8.1" 
+        else:
+            print("Non-NCAR machine, so no module changes will be made!")
+    elif FC_info == "pgf90":
+        if lmachine == "casper":
+            if OpenACC_info:
+                module_load="module purge ; module load ncarenv/1.3 pgi/20.4 openmpi/4.1.1 netcdf/4.7.4 cuda/11.0.3"
+            else:
+                module_load="module purge ; module load ncarenv/1.3 pgi/20.4 openmpi/4.1.1 netcdf/4.7.4"
+        else:
+            print("Not Casper, so no module changes will be made!")
+    elif FC_info == "nvfortran":
+        if lmachine == "casper":
+            if OpenACC_info:
+                module_load="module purge ; module load ncarenv/1.3 nvhpc/22.2 openmpi/4.1.1 netcdf/4.8.1 cuda/11.4.0"
+            else:
+                module_load="module purge ; module load ncarenv/1.3 nvhpc/22.2 openmpi/4.1.1 netcdf/4.8.1"
+        else:
+            print("Not Casper, so no module changes will be made!")
+    else:
+        sys.exit("FC_info is provided but only ifort and pgf90/nvfortran are supported!")
+        
     err=os.system("make clean")
-    err=os.system("make -j " + exe_list[exe]['args'])
+    err=os.system(module_load + "; make -j 4 " + exe_list[exe]['args'])
     err=os.system("mv ../run/cm1.exe ../run/" + exe)
     if err!=0:
         print("ERROR: Problem while building")
@@ -106,7 +142,7 @@ for exe in exe_list:
         for namelist_input in namelist_input_list:
             # create a log file name
             # set version number to a time stamp
-            log_fn_base = exe + "." + namelist_input
+            log_fn_base = exe + "." + FC_info + "." + HW + "." + namelist_input
             log_fn = cwd + '/logs/' + log_fn_base + "." + verNum + '.log'
 
             print('############################################')
@@ -121,7 +157,7 @@ for exe in exe_list:
             run_script = cwd+'/run_scripts/'+os.path.basename(log_fn)+".submit.csh" 
 
             # create the run script to submit to the queue    
-            create_runscript.create_runscript(exe, exe_list[exe], project_code, queue, cwd, run_dir, log_fn, run_script, namelist_input)
+            create_runscript.create_runscript(exe, exe_list[exe], project_code, FC_info, queue, module_load, cwd, run_dir, log_fn, run_script, namelist_input)
 
             # submit the run script to the queue
             err=os.system("qsub "+run_script)

--- a/runit
+++ b/runit
@@ -22,7 +22,7 @@ run_type = "control"
 add_to_experiment_list = True
 
 
-cm1_code_base = '/glade/scratch/sunjian/temp/CM1/'
+cm1_code_base = '/path/to/CM1/code/base/'
 project_code = 'NTDD0004'
 queue = 'casper'
 machine = 'casper'


### PR DESCRIPTION
This PR aims at addressing the issue https://github.com/sherimickelson/CM1_benchmarkingWF/issues/8.

The improvements include:

- Add a `machine` variable.
- Use `FC` and `USE_OPENACC` to determine the Fortran compiler and platform and include them in the output log file name.
- Load the environment modules based on the Fortran compiler and machine type (limited to NCAR's machines only).
- Load the consistent modules between `runit` and `create_runscript.py` scripts.
- Fix the queue name issue in the CPU runscript template.