### PR TITLE
Added legend to line plot.

### DIFF
--- a/plot/plot.py
+++ b/plot/plot.py
@@ -125,10 +125,11 @@ def line_info(_plt, Cvalues, Evalues, label):
                     else: #both are zero
                         sub.append(0.0)
                 #colors.append(_plt.plot(sub))
-                _plt.plot(sub)
+                _plt.plot(sub,label=os.path.basename(e))
         _plt.set_xlabel('time (min)')
         _plt.set_ylabel(label)
         _plt.grid(linestyle='--')
+        _plt.legend()
         return colors
 
 

--- a/runit.py
+++ b/runit.py
@@ -13,8 +13,8 @@ import create_runscript
 #####################
 
 ### IMPORTANT: uncomment the type of run this is
-run_type = "control"
-#run_type = "experiment"
+#run_type = "control"
+run_type = "experiment"
 
 # This code creates a json file that lists the log file to use in the plots.  This flag controls the ability to
 # add this set of log files to the existing experiment file lists or should this set be the only files listed under the 
@@ -31,7 +31,9 @@ namelist_input_list = [
 #    'namelist.asd04-128x512.input'
 ]
 exe_list = {
-#'cm1-mpi.exe': {'args': 'FC=ifort USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=false DEBUG=false',
+#
+# control
+#'cm1-mpi.exe': {'args': 'FC=nvfortran USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=false DEBUG=false',
 #                          'mpi':True,
 #                          'nodes':1,
 #                          'ncpus':36,
@@ -39,14 +41,16 @@ exe_list = {
 #                          'ngpus':0,
 #                          'walltime':'00:30:00'
 #                         }
-#'cm1-openacc.exe': {'args': 'FC=nvfortran USE_MPI=false USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
-#                          'mpi':False,
-#                          'nodes':1,
-#                          'ncpus':1,
-#                          'mpiprocs':1,
-#                          'ngpus':1,
-#                          'walltime':'00:30:00'
-#                         },
+#
+# Experiment 
+'cm1-openacc.exe': {'args': 'FC=nvfortran USE_MPI=false USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
+                          'mpi':False,
+                          'nodes':1,
+                          'ncpus':1,
+                          'mpiprocs':1,
+                          'ngpus':1,
+                          'walltime':'00:30:00'
+                         },
 'cm1-mpi-openacc.exe': {'args':'FC=nvfortran USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
                           'mpi':True,
                           'nodes':1,


### PR DESCRIPTION
This adds a legend to the line plot.  It should address issue #12.  Note that it uses the complete name of the log file in the legend.  The logfiles are currently rather long and descriptive, which makes the legend somewhat difficult to read. 