### PR TITLE
Add comparison and plot functions for droplet diagnostic

### DIFF
--- a/plot/plot.py
+++ b/plot/plot.py
@@ -22,6 +22,8 @@ def parse_it(log_file):
               'stats':{},
               'metrics':{},
               'performance':{},
+              'droplet_diag0':{},
+              'droplet_diag1':{},
               'total_time':''
     }
 
@@ -64,6 +66,25 @@ def parse_it(log_file):
                value = line.split()[-1]
                if key in info['metrics'].keys():
                    info['metrics'][key].append(float(value))               
+            # droplet 0th diagnostic stuff
+            elif "DROPLET_DIAG::" in line:
+               split = line.strip().replace("DROPLET_DIAG::","").split(':')
+               if  split[0].strip() in info['droplet_diag0'].keys():
+                   info['droplet_diag0'][split[0].strip()].append(split[1].strip())
+               else:
+                   info['droplet_diag0'][split[0].strip()] = [split[1].strip()]
+            # droplet 1st diagnostic stuff
+            elif "DROPLET_DIAG1::" in line:
+               split  = line.strip().replace("DROPLET_DIAG1::","").split(':')
+               tmpstr = split[1].split()
+               if  split[0].strip() in info['droplet_diag1'].keys():
+                   if  tmpstr[-1] in info['droplet_diag1'][split[0].strip()].keys():
+                       info['droplet_diag1'][split[0].strip()][tmpstr[-1]].append(tmpstr[0])
+                   else:
+                       info['droplet_diag1'][split[0].strip()][tmpstr[-1]] = [tmpstr[0]]
+               else:
+                   info['droplet_diag1'][split[0].strip()] = {}
+                   info['droplet_diag1'][split[0].strip()][tmpstr[-1]] = [tmpstr[0]]
             # performance and total time collection
             elif in_timing_section and ':' in line and len(line.split())==4 and 'Warning' not in line:
                 split = line.split()
@@ -139,7 +160,6 @@ def line_info(_plt, Cvalues, Evalues, label):
         _plt.legend()
         return colors
 
-
 def metric_plots(Cvalues, Evalues, f, save_plot):
 
     fig, ((pl1, pl2), (pl3,pl4)) = plt.subplots(2, 2, figsize=(12, 10))
@@ -156,6 +176,45 @@ def metric_plots(Cvalues, Evalues, f, save_plot):
     else:
         plt.show()
 
+def droplet_diag0_plot(vname, val, experiment, f, save_plot):
+
+    for i,filename in enumerate(experiment):
+        fig, ((pl1, pl2), (pl3,pl4)) = plt.subplots(2, 2, figsize=(12, 10))
+        plts = [pl1, pl2, pl3, pl4]
+        lens = len(vname[i])
+        for j in range(lens):
+            plts[j].plot(val[i][j],label=os.path.basename(filename))
+            plts[j].set_xlabel('diagnostic timestep')
+            plts[j].set_ylabel(vname[i][j])
+            plts[j].grid(linestyle='--')
+            plts[j].legend()
+        plt.subplots_adjust(bottom=0.25)
+        fig.suptitle("The relative differences in the Droplet 0-th Diagnostic Values |(exp-ctrl)|/max(|exp|,|ctrl|)\n"+f)
+        plt.tight_layout()
+        if  save_plot:
+            plt.savefig(f+'-'+os.path.basename(filename)+'-droplet-diag0.png')
+        else:
+            plt.show()
+
+def droplet_diag1_plot(vname, nlev, val, experiment, f, save_plot):
+
+    for i,filename in enumerate(experiment):
+        fig, ((pl1, pl2), (pl3,pl4)) = plt.subplots(2, 2, figsize=(12, 10))
+        plts = [pl1, pl2, pl3, pl4]
+        lens = len(vname[i])
+        for j in range(lens):
+            plts[j].plot(val[i][j],label=os.path.basename(filename))
+            plts[j].set_xlabel('diagnostic timestep')
+            plts[j].set_ylabel(vname[i][j]+" at lev "+nlev[i][j])
+            plts[j].grid(linestyle='--')
+            plts[j].legend()
+        plt.subplots_adjust(bottom=0.25)
+        fig.suptitle("The relative differences in the Droplet 1-st Diagnostic Values |(exp-ctrl)|/max(|exp|,|ctrl|)\n"+f)
+        plt.tight_layout()
+        if  save_plot:
+            plt.savefig(f+'-'+os.path.basename(filename)+'-droplet-diag1.png')
+        else:
+            plt.show()
 
 def compare_stat_values(Cvalues, Evalues, verbose):
 
@@ -166,6 +225,8 @@ def compare_stat_values(Cvalues, Evalues, verbose):
     diff = {}
     rel_err = []
     key = []
+    return_key = []
+    return_val = []
 
     if len(Cvalues) != len(Evalues):
         print("============================================")
@@ -207,10 +268,14 @@ def compare_stat_values(Cvalues, Evalues, verbose):
            for i in range(lens):
                print("\nRELATIVE DIFFERENCE IN VARIABLE "+key[ind[i]]+" : |(exp-ctrl)|/max(|exp|,|ctrl|)")
                print(diff[key[ind[i]]])
+               return_key.append(key[ind[i]])
+               return_val.append(diff[key[ind[i]]])
         else:
            for i in range(-1,-num_print-1,-1):     
                print("\nRELATIVE DIFFERENCE IN VARIABLE "+key[ind[i]]+" : |(exp-ctrl)|/max(|exp|,|ctrl|)")
                print(diff[key[ind[i]]])
+               return_key.append(key[ind[i]])
+               return_val.append(diff[key[ind[i]]])
 
         # Print the answer summary for this comparison
         print("============================================")
@@ -222,8 +287,91 @@ def compare_stat_values(Cvalues, Evalues, verbose):
 #    plt.plot(diff.values())
 #    plt.show()
 
-    return ok,fail,small
+    return ok,fail,small,return_key,return_val
 
+def compare_droplet1_values(Cvalues, Evalues, verbose):
+
+    ok = 0
+    fail = 0
+    small = 0
+
+    diff = {}
+    rel_err = [] 
+    vname = []
+    nlev = []
+    return_vname = []
+    return_nlev = []
+    return_val = []
+
+    if  len(Cvalues) != len(Evalues):
+        print("============================================")
+        print("Inside the Droplet 1st-order comparision:")
+        print("There is a mismatch in the amount of key values between the experiment (",len(Evalues),") versus control. (",len(Cvalues),")")
+    else:
+        for v in Cvalues.keys():
+            if  len(Cvalues[v]) != len(Evalues[v]):
+                print("Comparing key:  ",v)
+                print("There is a mismatch in the amount of comparisions between the experiment (",len(Evalues[v]),") versus control. (",len(Cvalues[v]),") Double check that both runs completed and that they ran for the same number of timesteps.")
+            else:
+                diff[v]    = {}
+                for k in Cvalues[v].keys():
+                    if  Cvalues[v][k] != Evalues[v][k]:
+                        rd = []
+                        flag = False
+                        for i in range(len(Cvalues[v][k])):
+                            if  (max(abs(float(Evalues[v][k][i])),abs(float(Cvalues[v][k][i]))) != 0):
+                                value = (abs(float(Evalues[v][k][i])-float(Cvalues[v][k][i]))) / \
+                                        max(abs(float(Evalues[v][k][i])),abs(float(Cvalues[v][k][i])))
+                                rd.append(value)
+                            else: #both are zero
+                                rd.append(0.0)
+                        rd_avg = np.average(rd)
+                        if  rd_avg > threshold:
+                            flag = True
+                        if  flag:
+                            diff[v][k] = rd
+                            rel_err.append(rd_avg)
+                            vname.append(v)
+                            nlev.append(k)
+                            fail+=1
+                        else:
+                            small+=1
+                            if verbose:
+                               print("\nDIFFERENCE DETECTED IN VARIABLE "+v+
+                                     ", but the mean relative difference is smaller than "+
+                                     str(threshold))
+                    else:
+                        if  verbose:
+                            print("\nNO DIFFERENCE IN VARIABLE "+v)
+                        ok+=1
+
+        # sort based on the mean error; ascending order
+        ind = np.lexsort((nlev,rel_err))
+        lens = len(rel_err)
+        # print out the variables with largest mean error
+        if  lens < num_print:
+            for i in range(lens):
+                print("\nRELATIVE DIFFERENCE IN VARIABLE "+vname[ind[i]]+" at LEV "+nlev[ind[i]]+" : |(exp-ctrl)|/max(|exp|,|ctrl|)")
+                print(diff[vname[ind[i]]][nlev[ind[i]]])
+                return_vname.append(vname[ind[i]])
+                return_nlev.append(nlev[ind[i]])
+                return_val.append(diff[vname[ind[i]]][nlev[ind[i]]])
+        else: 
+            for i in range(-1,-num_print-1,-1):
+                print("\nRELATIVE DIFFERENCE IN VARIABLE "+vname[ind[i]]+" at LEV "+nlev[ind[i]]+" : |(exp-ctrl)|/max(|exp|,|ctrl|)")
+                print(diff[vname[ind[i]]][nlev[ind[i]]])
+                return_vname.append(vname[ind[i]])
+                return_nlev.append(nlev[ind[i]])
+                return_val.append(diff[vname[ind[i]]][nlev[ind[i]]])
+
+        # Print the answer summary for this comparison
+        print("============================================")
+        print(str(ok)+" droplet_diag1 variables are identical.")
+        print(str(fail)+" droplet_diag1 variables show a mean relative difference > "+str(threshold))
+        print(str(small)+" droplet_diag1 variables show a mean relative difference <= "+str(threshold))
+    print("\n\n")
+
+    return ok,fail,small,return_vname,return_nlev,return_val
 
 def read_logs(json_file, save_plot, verbose):
 
@@ -237,6 +385,11 @@ def read_logs(json_file, save_plot, verbose):
     total_ok = 0
     total_fail = 0
     total_small = 0
+    vname_diag0 = []
+    val_diag0 = []
+    vname_diag1 = []
+    nlev_diag1 = []
+    val_diag1 = []
 
     # loop through the different sets of log files
     for f in sorted(fns.keys()):
@@ -255,10 +408,22 @@ def read_logs(json_file, save_plot, verbose):
         for e in experiment:
             print("============================================")
             print("Summary for "+fns[f]['control']+" compared to "+os.path.basename(e))
-            ok,fail,small = compare_stat_values(control['stats'], experiment[e]['stats'], verbose)
+            print("Stat output comparision:")
+            ok,fail,small,_,_ = compare_stat_values(control['stats'], experiment[e]['stats'], verbose)
             total_ok = total_ok+ok
             total_fail = total_fail+fail
             total_small = total_small+small
+            print("Droplet 0th-order diagnostic comparision:")
+            # we could reuse the compare_stat_values function for 0th-order diagnostic
+            _,_,_,vname,val = compare_stat_values(control['droplet_diag0'], experiment[e]['droplet_diag0'], verbose)
+            vname_diag0.append(vname)
+            val_diag0.append(val)
+            print("Droplet 1st-order diagnostic comparision:")
+            # we need a new function for 11111111111th-order diagnostic
+            _,_,_,vname,nlev,val = compare_droplet1_values(control['droplet_diag1'], experiment[e]['droplet_diag1'], verbose)
+            vname_diag1.append(vname)
+            nlev_diag1.append(nlev)
+            val_diag1.append(val)
 
         # print and plot performance
         performance_plot(control, os.path.basename(fns[f]['control']),
@@ -267,6 +432,13 @@ def read_logs(json_file, save_plot, verbose):
         # create metric plots
         metric_plots(control['metrics'], experiment, f, save_plot)
 
+        # droplet_diag0 plots: four variables with largest errors;
+        #                      may be different for different config cases 
+        droplet_diag0_plot(vname_diag0, val_diag0, experiment, f, save_plot)
+
+        # droplet_diag1 plots: four variables with largest errors;
+        #                      may be at different levels for different config cases 
+        droplet_diag1_plot(vname_diag1, nlev_diag1, val_diag1, experiment, f, save_plot)
 
     # Print a summary across all comparisons
     print("============================================")

--- a/runit.py
+++ b/runit.py
@@ -26,22 +26,29 @@ project_code = 'NTDD0004'
 queue = 'casper'
 machine = 'casper'
 namelist_input_list = [
-    'namelist.asd03-verify.input'
+     'namelist.baseline.dx=40m.short'
+#    'namelist.asd03-verify.input',
 #    'namelist.sas.input',
 #    'namelist.asd04-128x512.input'
 ]
 exe_list = {
-#
 # control
-#'cm1-mpi.exe': {'args': 'FC=nvfortran USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=false DEBUG=false',
-#                          'mpi':True,
-#                          'nodes':1,
-#                          'ncpus':36,
-#                          'mpiprocs':36,
-#                          'ngpus':0,
-#                          'walltime':'00:30:00'
-#                         }
-#
+'cm1-mpi-ifort.exe': {'args': 'FC=ifort USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=false DEBUG=false',
+                          'mpi':True,
+                          'nodes':1,
+                          'ncpus':36,
+                          'mpiprocs':36,
+                          'ngpus':0,
+                          'walltime':'00:30:00'
+                         },
+'cm1-mpi-nvhpc.exe': {'args': 'FC=nvfortran USE_MPI=true USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=false DEBUG=false',
+                          'mpi':True,
+                          'nodes':1,
+                          'ncpus':36,
+                          'mpiprocs':36,
+                          'ngpus':0,
+                          'walltime':'00:30:00'
+                         },
 # Experiment 
 'cm1-openacc.exe': {'args': 'FC=nvfortran USE_MPI=false USE_OPENMP=false USE_DOUBLE=false USE_OPENACC=true DEBUG=false',
                           'mpi':False,
@@ -113,7 +120,7 @@ for exe in exe_list:
     elif FC_info == "pgf90":
         if machine == "casper":
             if OpenACC_info:
-                module_load="module purge ; module load ncarenv/1.3 pgi/20.4 openmpi/4.1.1 netcdf/4.7.4 cuda/11.4.0"
+                module_load="module purge ; module load ncarenv/1.3 pgi/20.4 openmpi/4.1.1 netcdf/4.7.4 cuda/11.6"
             else:
                 module_load="module purge ; module load ncarenv/1.3 pgi/20.4 openmpi/4.1.1 netcdf/4.7.4"
         else:
@@ -121,7 +128,7 @@ for exe in exe_list:
     elif FC_info == "nvfortran":
         if machine == "casper":
             if OpenACC_info:
-                module_load="module purge ; module load ncarenv/1.3 nvhpc/22.2 openmpi/4.1.1 netcdf/4.8.1 cuda/11.4.0"
+                module_load="module purge ; module load ncarenv/1.3 nvhpc/22.2 openmpi/4.1.1 netcdf/4.8.1 cuda/11.6"
             else:
                 module_load="module purge ; module load ncarenv/1.3 nvhpc/22.2 openmpi/4.1.1 netcdf/4.8.1"
         else:
@@ -155,7 +162,7 @@ for exe in exe_list:
 
             # set some variables for this setup
             run_dir = cm1_code_base + "/run/"
-            run_script = cwd+'/run_scripts/'+os.path.basename(log_fn)+".submit.csh" 
+            run_script = cwd+'/run_scripts/'+os.path.basename(log_fn)+".submit.sh" 
 
             # create the run script to submit to the queue    
             create_runscript.create_runscript(exe, exe_list[exe], project_code, queue, module_load, 


### PR DESCRIPTION
This PR updates the verification framework to post-process the droplet diagnostic output.
- For the 0th-order droplet diagnostic, we focus on the four variables with largest relative errors (it could be fewer than four if two simulations agree very well with each other).
- For the 1st-order droplet diagnostic, we focus on the four variables with largest relative errors (it could be different variables at different levels for each pair of comparison).
- For both 0th-order and 1st-order droplet diagnostic, the selected variables could be different between different configurations. Thus we will calculate the statistics and make plots individually for each pair of comparison.
- Some minor fixes to the `runit.py` script.

An example of plot for the 0th-order droplet diagnostic between a CPU run (intel) and MPI+OpenACC run looks like:
![image](https://user-images.githubusercontent.com/8117233/178080040-b5d9c7ca-3bfc-4b26-bcf1-ca2c05934559.png)

An example of plot for the 1st-order droplet diagnostic between a CPU run (intel) and MPI+OpenACC run looks like:
![image](https://user-images.githubusercontent.com/8117233/178079994-80262756-5442-436e-bdf7-1d75db1e86d2.png)